### PR TITLE
Removed Github actions version numbers in favor of commit hashes for …

### DIFF
--- a/cron.yml
+++ b/cron.yml
@@ -12,8 +12,8 @@ jobs:
       API_SECRET: ${{ secrets.API_SECRET }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561
         with:
           node-version: '14'
       - run: npm install


### PR DESCRIPTION
Removed Github Actions' version numbers in favor of commit hashes for security purposes.

In case of a security breach in any of the Github actions repositories where code can be introduced that can steal API keys.

